### PR TITLE
Add validation foreground colors

### DIFF
--- a/themes/Framer Syntax-color-theme.json
+++ b/themes/Framer Syntax-color-theme.json
@@ -129,8 +129,10 @@
     "inputOption.activeBorder": "#eee",
     "inputValidation.errorBackground": "#FF5459",
     "inputValidation.errorBorder": "#4C292A",
+    "inputValidation.errorForeground": "#fff",
     "inputValidation.infoBackground": "#5ec4ff",
     "inputValidation.infoBorder": "#539afc",
+    "inputValidation.infoForeground": "#fff",
     "inputValidation.warningBackground": "#fff",
     "inputValidation.warningBorder": "#d98e48",
 


### PR DESCRIPTION
Fixes #5 

VS Code 1.28 adds support for [input validation foreground](https://code.visualstudio.com/updates/v1_28#_new-theme-colors), which will help fix the color issues on errors. This PR adds support for that:

![image](https://user-images.githubusercontent.com/35271042/46628154-84dff900-caf1-11e8-8705-616b08238c25.png)
